### PR TITLE
base/Dockerfile.rhel: don't use double brackets.

### DIFF
--- a/base/Dockerfile.rhel
+++ b/base/Dockerfile.rhel
@@ -4,7 +4,7 @@ RUN INSTALL_PKGS=" \
       socat findutils lsof bind-utils gzip \
       procps-ng rsync \
       " && \
-    if [[ ! -e /usr/bin/yum ]]; then ln -s /usr/bin/microdnf /usr/bin/yum; fi && \
+    if [ ! -e /usr/bin/yum ]; then ln -s /usr/bin/microdnf /usr/bin/yum; fi && \
     yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     yum clean all && rm -rf /var/cache/*
 LABEL io.k8s.display-name="OpenShift Base" \


### PR DESCRIPTION
bashlex doesn't like them. It won't parse when OCP automation goes through mangling things. I don't know why, and it's easier to just change this.