### PR TITLE
ipfailover: Calculate IP key from IPv6 addresses

### DIFF
--- a/ipfailover/keepalived/lib/config-generators.sh
+++ b/ipfailover/keepalived/lib/config-generators.sh
@@ -217,6 +217,25 @@ vrrp_instance ${instance_name} {
 
 
 #
+#  Generate integer from IP address.
+#
+#  Examples:
+#      generate_ipkey 192.0.2.100
+#      generate_ipkey 2001::db8:77::123
+#
+function generate_ipkey() {
+  local ipaddr ; ipaddr="$1"
+
+  if [[ "$ipaddr" = *:* ]]; then
+    # IPv6 in hex
+    printf "%d" "0x0${ipaddr##*:}"
+  else
+    echo "${ipaddr##*.}"
+  fi
+}
+
+
+#
 #  Generate failover configuration.
 #
 #  Examples:
@@ -235,7 +254,7 @@ $(generate_global_config "${HA_CONFIG_NAME}")
 $(generate_script_config "${ipaddr}" "${port}")
 "
 
-  local ipkey ; ipkey=$(echo "${ipaddr}" | cut -f 4 -d '.')
+  local ipkey ; ipkey=$(generate_ipkey "${ipaddr}")
   local ipslot=$((ipkey % 128))
 
   local nodecount


### PR DESCRIPTION
When configured with IPv6 addresses the Keepalived configuration
generation would fail when attemting to extract the last octet from an
IP address, e.g.:

  2001::db8:77::123: syntax error in expression (error token is
  "::db8:77::123")

The code made an assumption that IP addresses are always separated by
periods ("."). With this change IPv6 addresses are handled separately
and the last field is extracted before being converted from Base-16 to
Base-10 for further computations.