### PR TITLE
Adding write perms for http-proxy

### DIFF
--- a/egress/http-proxy/Dockerfile
+++ b/egress/http-proxy/Dockerfile
@@ -10,7 +10,8 @@ RUN INSTALL_PKGS="squid" && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
     rmdir /var/log/squid /var/spool/squid && \
-    rm -f /etc/squid/squid.conf
+    rm -f /etc/squid/squid.conf && \
+    chmod -R og+w /etc/squid
 
 ADD egress-http-proxy.sh /bin/egress-http-proxy.sh
 


### PR DESCRIPTION
Addresses `/bin/egress-http-proxy.sh: line 78: /etc/squid/squid.conf: Permission denied` seen when running egress-http-proxy pod on cluster.