### PR TITLE
base/*: Set skip_missing_names_on_install=0 in /etc/yum.conf

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -11,8 +11,8 @@ RUN INSTALL_PKGS=" \
       which tar wget hostname sysvinit-tools util-linux \
       socat tree findutils lsof bind-utils shadow-utils \
       " && \
+    echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
     yum install -y ${INSTALL_PKGS} && \
-    rpm -V ${INSTALL_PKGS} && \
     yum clean all && \
     mkdir -p /var/lib/origin
 

--- a/base/Dockerfile.centos7
+++ b/base/Dockerfile.centos7
@@ -10,8 +10,8 @@ RUN INSTALL_PKGS=" \
       which tar wget hostname sysvinit-tools util-linux \
       socat tree findutils lsof bind-utils shadow-utils \
       " && \
+    echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
     yum install -y ${INSTALL_PKGS} && \
-    rpm -V ${INSTALL_PKGS} && \
     yum clean all && \
     mkdir -p /var/lib/origin
 

--- a/base/Dockerfile.rhel
+++ b/base/Dockerfile.rhel
@@ -5,6 +5,7 @@ RUN INSTALL_PKGS=" \
       procps-ng rsync \
       " && \
     if [ ! -e /usr/bin/yum ]; then ln -s /usr/bin/microdnf /usr/bin/yum; fi && \
+    echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
     yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     yum clean all && rm -rf /var/cache/*
 LABEL io.k8s.display-name="OpenShift Base" \

--- a/base/Dockerfile.rhel7
+++ b/base/Dockerfile.rhel7
@@ -10,8 +10,8 @@ RUN INSTALL_PKGS=" \
       which tar wget hostname sysvinit-tools util-linux \
       socat tree findutils lsof bind-utils shadow-utils \
       " && \
+    echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
     yum --disablerepo=origin-local-release install -y $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
     yum clean all && \
     mkdir -p /var/lib/origin
 


### PR DESCRIPTION
Ensure yum install fails if a package is missing.