### PR TITLE
Add jq (used in CI scripts)

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -10,6 +10,7 @@ COPY *.repo /etc/yum.repos.d/
 RUN INSTALL_PKGS=" \
       which tar wget hostname sysvinit-tools util-linux \
       socat tree findutils lsof bind-utils shadow-utils \
+      jq \
       " && \
     echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
     yum install -y ${INSTALL_PKGS} && \

--- a/base/Dockerfile.centos7
+++ b/base/Dockerfile.centos7
@@ -9,6 +9,7 @@ FROM openshift/origin-source
 RUN INSTALL_PKGS=" \
       which tar wget hostname sysvinit-tools util-linux \
       socat tree findutils lsof bind-utils shadow-utils \
+      jq \
       " && \
     echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
     yum install -y ${INSTALL_PKGS} && \

--- a/base/Dockerfile.rhel
+++ b/base/Dockerfile.rhel
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 RUN INSTALL_PKGS=" \
       which tar wget hostname shadow-utils \
       socat findutils lsof bind-utils gzip \
-      procps-ng rsync \
+      procps-ng rsync jq \
       " && \
     if [ ! -e /usr/bin/yum ]; then ln -s /usr/bin/microdnf /usr/bin/yum; fi && \
     echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \

--- a/base/Dockerfile.rhel7
+++ b/base/Dockerfile.rhel7
@@ -9,6 +9,7 @@ FROM rhel7
 RUN INSTALL_PKGS=" \
       which tar wget hostname sysvinit-tools util-linux \
       socat tree findutils lsof bind-utils shadow-utils \
+      jq \
       " && \
     echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
     yum --disablerepo=origin-local-release install -y $INSTALL_PKGS && \


### PR DESCRIPTION
fixes https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/23567/pull-ci-openshift-origin-master-e2e-aws/12227


```
  - containerID: docker://ebf65d612c94a8523fd3a066b60a560d653d1e7638785b1b84ff6f78ffdce74a
    image: registry.svc.ci.openshift.org/ci-op-05hlp238/stable:installer
    imageID: docker-pullable://docker-registry.default.svc:5000/ci-op-0tx5pm8l/stable-initial@sha256:382192de8b08069c20296073f937df3c00b72d5a78ebf9bbb8d9c1560c8c8e84
    lastState: {}
    name: setup
    ready: false
    restartCount: 0
    state:
      terminated:
        containerID: docker://ebf65d612c94a8523fd3a066b60a560d653d1e7638785b1b84ff6f78ffdce74a
        exitCode: 1
        finishedAt: 2019-08-21T09:13:24Z
        message: |
          Lease acquired, installing...
          Installing from release registry.svc.ci.openshift.org/ci-op-2cihqg1y/release@sha256:659231794102125f4bd974f6b3936e5dc6c243739f85cf89c0d30ccb5771b3f5
          /bin/sh: line 36: jq: command not found
          /bin/sh: line 36: jq: command not found
          level=fatal msg="failed to fetch Terraform Variables: failed to fetch dependency of \"Terraform Variables\": failed to fetch dependency of \"Bootstrap Ignition Config\": failed to fetch dependency of \"Common Manifests\": failed to generate asset \"DNS Config\": getting public zone for \"origin-ci-int-aws.dev.rhcloud.com\": listing hosted zones: Throttling: Rate exceeded\n\tstatus code: 400, request id: d9947a89-7ba8-4ac9-a857-778ca2f24eef"
        reason: Error
        startedAt: 2019-08-21T09:13:13Z
```

/cc @smarterclayton 