### PR TITLE
Bumping squid to use 4.8

### DIFF
--- a/egress/http-proxy/Dockerfile.origin
+++ b/egress/http-proxy/Dockerfile.origin
@@ -1,0 +1,21 @@
+#
+# This is the egress router HTTP proxy for OpenShift Origin
+#
+# The standard name for this image is openshift/origin-egress-http-proxy
+#
+# This image is intended only to be used for CI for the time being
+
+FROM openshift/origin-base
+
+ADD squid.repo /etc/yum.repos.d/squid.repo
+
+RUN INSTALL_PKGS="squid" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    rmdir /var/log/squid /var/spool/squid && \
+    rm -f /etc/squid/squid.conf
+
+ADD egress-http-proxy.sh /bin/egress-http-proxy.sh
+
+ENTRYPOINT /bin/egress-http-proxy.sh

--- a/egress/http-proxy/squid.repo
+++ b/egress/http-proxy/squid.repo
@@ -1,0 +1,7 @@
+[squid]
+name=Squid repo for RHEL Linux - 7
+#IL mirror
+baseurl=http://www1.ngtech.co.il/repo/rhel/7/x86_64/
+failovermethod=priority
+enabled=1
+gpgcheck=0


### PR DESCRIPTION
Allowing the installation of `squid 4.8` by adding their yum repo.
This allows us to use a `TLS 1.3` handshake protocol since `3.5` only allowed up to `TLS 1.2`, this is to resolve the issue seen with `podman`