### PR TITLE
egress/dns-proxy: switch to haproxy 2.x

### DIFF
--- a/egress/dns-proxy/Dockerfile
+++ b/egress/dns-proxy/Dockerfile
@@ -6,7 +6,7 @@
 FROM openshift/origin-base
 
 # HAProxy 1.6+ version is needed to leverage DNS resolution at runtime.
-RUN INSTALL_PKGS="haproxy18 rsyslog" && \
+RUN INSTALL_PKGS="haproxy20 rsyslog" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
Move to haproxy 2.x which is packaged here:

https://pkgs.devel.redhat.com/cgit/rpms/haproxy/log/?h=rhaos-4.4-rhel-7