### PR TITLE
Allow customization for port and access_log in http-proxy

### DIFF
--- a/egress/http-proxy/egress-http-proxy.sh
+++ b/egress/http-proxy/egress-http-proxy.sh
@@ -76,9 +76,9 @@ CONF=/etc/squid/squid.conf
 rm -f ${CONF}
 
 cat > ${CONF} <<EOF
-http_port 8080
+http_port ${EGRESS_HTTP_PROXY_LISTEN_PORT:-8080}
 cache deny all
-access_log none all
+access_log ${EGRESS_HTTP_PROXY_ACCESS_LOG:-none} all
 debug_options ALL,0
 shutdown_lifetime 0
 EOF


### PR DESCRIPTION
Add two extra environment variables to allow users to:
 - change the default port 8080
 - set a file location for the access_log file for auditing purposes whenever it's required as nowadays they're not even logged