### PR TITLE
Fix link for rhel8 Dockerfile

### DIFF
--- a/base/Dockerfile.rhel8
+++ b/base/Dockerfile.rhel8
@@ -1,1 +1,1 @@
-Dockerfile.rhel7
+Dockerfile.rhel


### PR DESCRIPTION
It has to point to Dockerfile.rhel not Dockerfile.rhel7:
https://github.com/openshift/release/blob/a15012e5874b8b75b3609c1143ae7a583899e5b0/ci-operator/config/openshift/images/openshift-images-release-4.6.yaml#L29