### PR TITLE
Bug 1875946: Pod process container does not correctly reap zombie process with shareProcessNamespace: true

### DIFF
--- a/pod/pod.go
+++ b/pod/pod.go
@@ -1,15 +1,69 @@
 package main
 
 import (
+	"log"
 	"os"
 	"os/signal"
 	"syscall"
 )
 
+var reaperErrLog *log.Logger
+
+func init() {
+	reaperErrLog = log.New(os.Stderr, "reaper: ", log.LstdFlags|log.Lmicroseconds)
+}
+
+func reapChildProcesses() {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGCHLD)
+
+	for {
+		// Block until SIGCHLD signal is received.
+		<-c
+		reapChildProcessesHelper()
+	}
+}
+
+func reapChildProcessesHelper() {
+	for {
+		// Pid -1 means to wait for any child process.
+		// With syscall.WNOHANG option set, function will
+		// not block and will exit immediately if no child
+		// process has exited.
+		pid, err := syscall.Wait4(-1, nil, syscall.WNOHANG, nil)
+		switch err {
+		case nil:
+			// If pid == 0 then one or more child processes still exist,
+			// but have not yet changed state so we return and wait
+			// for another SIGCHLD.
+			if pid == 0 {
+				return
+			}
+		case syscall.ECHILD:
+			// No more child processes to reap. We can return and wait
+			// for another SIGCHLD signal.
+			return
+		case syscall.EINTR:
+			// Got interrupted. Shouldn't happen with WNOHANG option,
+			// but it is better to handle it anyway and try again.
+		default:
+			// Some other unexpected error. Return and wait for
+			// another SIGCHLD signal.
+			reaperErrLog.Printf("Unexpected error waiting for child process: %v\n", err)
+			return
+		}
+	}
+}
+
 func main() {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, os.Kill, syscall.SIGTERM)
 
-	// Block until a signal is received.
+	if os.Getpid() == 1 {
+		log.Println("Starting reaper")
+		go reapChildProcesses()
+	}
+
+	// Block until a SIGINT, SIGKILL or SIGTERM signal is received.
 	<-c
 }


### PR DESCRIPTION
The purpose of this pull request is to add handling the SIGCHLD signal and proper reaping of the zombie processes to the `pod` binary.

This is to avoid exhaustion of the process table slots in some long running scenarios and to keep the behavior of pods consistent with the vanilla kubernetes distribution, when using [shareProcessNamespace: true](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/).

## Why
The default configuration of the cri-o deployed by Openshift/OKD (version 4) specifies the `pause_command = "/usr/bin/pod"`. This means that when the user spawns a pod with `shareProcessNamespace: true`, the pod binary will be launched as the init process in the pod's pid namespace. If one of the containers in that pod has an exec readiness probe configured, that executes some kind of command that may sometimes exceed the readiness probe's timeout, all processes launched by this command will be left as zombie/defunct processes and will never be cleaned up. That's because the /usr/bin/pod, running as the PID 1 process, does not currently handle the SIGCHLD signal and does not reap the zombie processes. Over a longer time span this may fill the process table size available inside the container namespace and cause errors like "Cannot fork" and cause other problems during the pod's main container runtime.

The pause container used in the vanilla kubernetes distribution handles the SIGCHLD and reaps the zombies as can be seen in the [source code](https://github.com/kubernetes/kubernetes/blob/master/build/pause/pause.c).

## Steps to reproduce on OKD/Openshift 4 cluster
1. Deploy Openshift/OKD 4 cluster
2. Create a pod with `shareProcessNamespace: true` and an exec readiness probe that will timeout. Example of a pod:
```
apiVersion: v1
kind: Pod
metadata:
  name: test
spec:
  shareProcessNamespace: true
  containers:
  - name: ubuntu
    image: ubuntu
    command:
      - /bin/tail
      - -f
      - /dev/null
    readinessProbe:
      exec:
        command:
          - /bin/sh
          - -c
          - sleep 5
      periodSeconds: 3
      timeoutSeconds: 1
```
3. Do `kubectl exec -it test bash`, run the `top` command, and observe how a new zombie process appears every 3 seconds.

## Steps to reproduce with Docker (or other container runtime)
1. Run a container with the image containing the `pod` binary. For example, use the image from the latest release of OKD (`pod` image specified [here](https://github.com/openshift/okd/releases/tag/4.5.0-0.okd-2020-08-12-020541)).
```
docker run -d --name pod quay.io/openshift/okd-content@sha256:1207114d4db1bdb9431fdcc890b6813e889fdcfba94900396f0ab9ca4f0c5dbd
```
2. Exec into the container and run `top`.
```
docker exec -it pod top
```
3. From a different terminal, create another container in the same pid namespace.
```
docker run -it  --rm  --pid=container:pod ubuntu bash
```
4. From the new container, run a command that will spawn a few children and then exit without waiting.
```
for i in {1..10}; do $(sleep 2) & done; exit
```
5. Observe how new zombie processes appear in the `top` output.


When you repeat steps mentioned above, but with an image that contains `pod` binary with the added SIGCHLD handling, no zombie processes are left hanging. 

## References:

* https://github.com/kubernetes/kubernetes/tree/master/build/pause
* https://github.com/ramr/go-reaper
* https://github.com/hashicorp/go-reap
* https://linux.die.net/man/2/waitpid
* https://www.ianlewis.org/en/almighty-pause-container
* http://www.microhowto.info/howto/reap_zombie_processes_using_a_sigchld_handler.html