### PR TITLE
Make python3 available in ubi7 base image

### DIFF
--- a/base/Dockerfile.rhel
+++ b/base/Dockerfile.rhel
@@ -1,17 +1,19 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6
 
-# ubi8 does not have a python binary in PATH. Installing it explicitly if /usr/bin/python
-# does not exist so this image is consistent with the ubi7 base.
+# A ubi7 base image will expose python2 in /usr/bin/python. It will also provide
+# python3 which will be used only if explicitly called by /usr/bin/python3.
+# A ubi8 image will expose python3 as /usr/bin/python. It does not contain
+# python2. Subsequent layers should install if it needed.
 
 RUN INSTALL_PKGS=" \
       which tar wget hostname shadow-utils \
       socat findutils lsof bind-utils gzip \
-      procps-ng rsync iproute \
+      procps-ng rsync iproute diffutils python3 \
       " && \
     if [ ! -e /usr/bin/yum ]; then ln -s /usr/bin/microdnf /usr/bin/yum; fi && \
     echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
     yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-    ( test -e /usr/bin/python || ( yum install -y --setopt=tsflags=nodocs python3 && alternatives --set python /usr/bin/python3 ) ) && \
+    ( test -e /usr/bin/python ||  alternatives --set python /usr/bin/python3 ) && \
     yum clean all && rm -rf /var/cache/*
 LABEL io.k8s.display-name="OpenShift Base" \
       io.k8s.description="This is the base image from which all OpenShift images inherit."


### PR DESCRIPTION
This is an intermediate step as we migrate OCP 4.6 to a rhel8
base. During this work, the console downloader was migrated
to python3, but python3 was previously unavailable in the ocp
base image.