### PR TITLE
Bug 1883690: Enable x509 common name matching

### DIFF
--- a/base/Dockerfile.rhel
+++ b/base/Dockerfile.rhel
@@ -18,5 +18,9 @@ RUN INSTALL_PKGS=" \
     yum install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=False ${INSTALL_PKGS} && \
     ( test -e /usr/bin/python ||  alternatives --set python /usr/bin/python3 ) && \
     yum clean all && rm -rf /var/cache/*
+
+# Enable x509 common name matching for golang 1.15 and beyond.
+ENV GODEBUG=x509ignoreCN=0
+
 LABEL io.k8s.display-name="OpenShift Base" \
       io.k8s.description="This is the base image from which all OpenShift images inherit."


### PR DESCRIPTION
OCP 4.6 uses golang 1.15. 1.15 has deprecated the behavior of
treating the CommonName field on X.509 certificates as a
host name when no Subject Alternative Names are present.
https://golang.google.cn/doc/go1.15#commonname

Additional context:  https://coreos.slack.com/archives/CEKNRGF25/p1600867749007700