### PR TITLE
Updating openshift-enterprise-base builder & base images to be consistent with ART

### DIFF
--- a/base/Dockerfile.rhel
+++ b/base/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift
 
 # A ubi7 base image will expose python2 in /usr/bin/python. It will also provide
 # python3 which will be used only if explicitly called by /usr/bin/python3.


### PR DESCRIPTION
Updating openshift-enterprise-base builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/openshift-enterprise-base.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
