### PR TITLE
Updating ose-egress-http-proxy builder & base images to be consistent with ART

### DIFF
--- a/egress/http-proxy/Dockerfile
+++ b/egress/http-proxy/Dockerfile
@@ -3,7 +3,7 @@
 #
 # The standard name for this image is openshift/origin-egress-http-proxy
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 
 RUN INSTALL_PKGS="squid" && \
     yum install -y $INSTALL_PKGS && \


### PR DESCRIPTION
Updating ose-egress-http-proxy builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/ose-egress-http-proxy.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.