### PR TITLE
Bug 1896170: Egress router: Add iptables package to Dockerfile

### DIFF
--- a/egress/router/Dockerfile
+++ b/egress/router/Dockerfile
@@ -5,7 +5,7 @@
 
 FROM registry.svc.ci.openshift.org/ocp/4.6:base
 
-RUN INSTALL_PKGS="iproute iputils" && \
+RUN INSTALL_PKGS="iproute iputils iptables" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all


### PR DESCRIPTION
Side effect of the rhel 8 transition.

`registry.svc.ci.openshift.org/ocp/4.5:base` includes iptables but `registry.svc.ci.openshift.org/ocp/4.6:base` does not, so let's install it so the egress-router can work again.

https://bugzilla.redhat.com/show_bug.cgi?id=1896170 for more context.