### PR TITLE
Revert "Merge pull request #52 from jupierce/bump_haproxy"

### DIFF
--- a/egress/dns-proxy/Dockerfile
+++ b/egress/dns-proxy/Dockerfile
@@ -6,7 +6,7 @@
 FROM registry.svc.ci.openshift.org/ocp/4.7:base
 
 # HAProxy 1.6+ version is needed to leverage DNS resolution at runtime.
-RUN INSTALL_PKGS="haproxy22 rsyslog" && \
+RUN INSTALL_PKGS="haproxy20 rsyslog" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
This reverts commit 9d0f10cc5272b06adc303f669c20c98575da08e6, reversing
changes made to 791e631ca350e8093c6d916ff7aaaa4d13d9cd52.

haproxy-2.2.4 will not allow us to disable HTX anymore which means
client/servers will always get down-cased headers. As this may break
customers upgrading from OpenShift 4.6 => 4.7 we plan to add an API in
4.7 that will allow customers to specify case adjustment for various
routes. With that knob in place we will target 2.2.x for OpenShift 4.8
which is captured in this enhancement proposal:

  https://github.com/openshift/enhancements/pull/550

PR that reverts the router to haproxy20:

  https://github.com/openshift/router/pull/226

Related tickets:
- https://issues.redhat.com/browse/NE-426
- https://issues.redhat.com/browse/NE-473