### PR TITLE
Bug 1907924: enable madvdontneed for golang

### DIFF
--- a/base/Dockerfile.rhel
+++ b/base/Dockerfile.rhel
@@ -20,7 +20,8 @@ RUN INSTALL_PKGS=" \
     yum clean all && rm -rf /var/cache/*
 
 # Enable x509 common name matching for golang 1.15 and beyond.
-ENV GODEBUG=x509ignoreCN=0
+# Enable madvdontneed=1, for golang < 1.16 https://github.com/golang/go/issues/42330
+ENV GODEBUG=x509ignoreCN=0,madvdontneed=1
 
 LABEL io.k8s.display-name="OpenShift Base" \
       io.k8s.description="This is the base image from which all OpenShift images inherit."


### PR DESCRIPTION
Golang 1.12 changed to use MADV_FREE. MADV_FREE is somewhat faster than MADV_DONTNEED; however, the kernel will not try and reclaim memory in golang processes until the system is memory constrained. Cloud servers can potentially page out executable caches, which can cause IOPS throttles. Since golang 1.16  will be changing the default to MADV_DONTNEED, we are going to enable the flag by default.

This patch is 1 of 2. We need a separate patch in MCO to enable the system daemons (Kubelet and Crio).

https://github.com/golang/go/issues/42330