### PR TITLE
egress/dns-proxy: Switch to haproxy22

### DIFF
--- a/egress/dns-proxy/Dockerfile
+++ b/egress/dns-proxy/Dockerfile
@@ -6,7 +6,7 @@
 FROM registry.svc.ci.openshift.org/ocp/4.7:base
 
 # HAProxy 1.6+ version is needed to leverage DNS resolution at runtime.
-RUN INSTALL_PKGS="haproxy20 rsyslog" && \
+RUN INSTALL_PKGS="haproxy22 rsyslog" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
Switch to haproxy22 package. This is a move from haproxy-2.0 series to haproxy-2.2 in OCP-4.8.

