### PR TITLE
[WIP] keepalived: pin keepalived to 2.0.10

### DIFF
--- a/ipfailover/keepalived/Dockerfile
+++ b/ipfailover/keepalived/Dockerfile
@@ -5,7 +5,7 @@
 #
 FROM registry.ci.openshift.org/ocp/4.8:base
 
-RUN INSTALL_PKGS="kmod keepalived iproute psmisc nmap-ncat net-tools ipset ipset-libs" && \
+RUN INSTALL_PKGS="kmod keepalived-2.0.10 iproute psmisc nmap-ncat net-tools ipset ipset-libs" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all


### PR DESCRIPTION
On metal-ipi, we're investigating failures that result in the VIP ending
up on multiple hosts. This behavior seems to line up with when we bumped
to 2.1.5, this PR pins keepalived to 2.0.10 to test that theory.

Also see: https://github.com/openshift/release/pull/18334