### PR TITLE
Bug 1960035: Add iptables shims to ipfailover-keepalived image

### DIFF
--- a/ipfailover/keepalived/Dockerfile
+++ b/ipfailover/keepalived/Dockerfile
@@ -11,6 +11,13 @@ RUN INSTALL_PKGS="kmod keepalived iproute psmisc nmap-ncat net-tools ipset ipset
     yum clean all
 COPY . /var/lib/ipfailover/keepalived/
 
+COPY iptables-scripts/iptables /usr/sbin/
+COPY iptables-scripts/iptables-save /usr/sbin/
+COPY iptables-scripts/iptables-restore /usr/sbin/
+COPY iptables-scripts/ip6tables /usr/sbin/
+COPY iptables-scripts/ip6tables-save /usr/sbin/
+COPY iptables-scripts/ip6tables-restore /usr/sbin/
+
 LABEL io.k8s.display-name="OpenShift IP Failover" \
       io.k8s.description="This is a component of OpenShift and runs a clustered keepalived instance across multiple hosts to allow highly available IP addresses." \
       io.openshift.tags="openshift,ha,ip,failover"

--- a/ipfailover/keepalived/iptables-scripts/ip6tables
+++ b/ipfailover/keepalived/iptables-scripts/ip6tables
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/ip6tables "$@"

--- a/ipfailover/keepalived/iptables-scripts/ip6tables-restore
+++ b/ipfailover/keepalived/iptables-scripts/ip6tables-restore
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/ip6tables-restore "$@"

--- a/ipfailover/keepalived/iptables-scripts/ip6tables-save
+++ b/ipfailover/keepalived/iptables-scripts/ip6tables-save
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/ip6tables-save "$@"

--- a/ipfailover/keepalived/iptables-scripts/iptables
+++ b/ipfailover/keepalived/iptables-scripts/iptables
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/iptables "$@"

--- a/ipfailover/keepalived/iptables-scripts/iptables-restore
+++ b/ipfailover/keepalived/iptables-scripts/iptables-restore
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/iptables-restore "$@"

--- a/ipfailover/keepalived/iptables-scripts/iptables-save
+++ b/ipfailover/keepalived/iptables-scripts/iptables-save
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/iptables-save "$@"


### PR DESCRIPTION
The registry.ci.openshift.org/ocp/4.8:base image that the
ipfailover-keepalived container is based on doesn't include iptables,
which keepalived needs. This patch uses the same technique that's used
in [openshift-sdn's](https://github.com/openshift/sdn) container images,
which is to utilize the host's iptables executable.

With this commit, the ipfailover-keepalived image will require that the
host filesystem is mounted at `/host` inside the container, although
it's possible that just mounting the host's `/usr/sbin` at
`/host/usr/sbin/` will work as well