### PR TITLE
Switch to haproxy24

### DIFF
--- a/egress/dns-proxy/Dockerfile
+++ b/egress/dns-proxy/Dockerfile
@@ -6,7 +6,7 @@
 FROM registry.ci.openshift.org/ocp/4.8:base
 
 # HAProxy 1.6+ version is needed to leverage DNS resolution at runtime.
-RUN INSTALL_PKGS="haproxy22 rsyslog" && \
+RUN INSTALL_PKGS="haproxy24 rsyslog" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
OCP 4.9 router is moving to haproxy-2.4; router PR https://github.com/openshift/router/pull/313