### PR TITLE
Revert to haproxy22

### DIFF
--- a/egress/dns-proxy/Dockerfile
+++ b/egress/dns-proxy/Dockerfile
@@ -6,7 +6,7 @@
 FROM registry.ci.openshift.org/ocp/4.9:base
 
 # HAProxy 1.6+ version is needed to leverage DNS resolution at runtime.
-RUN INSTALL_PKGS="haproxy24 rsyslog" && \
+RUN INSTALL_PKGS="haproxy22 rsyslog" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
This partially reverts PR #95.

We are switching back to haproxy-2.2 as our performance analysis shows
there are performance degradations when compared to the haproxy-2.2
series.