### PR TITLE
Add a script to remove all failover configurations.

### DIFF
--- a/ipfailover/keepalived/Dockerfile
+++ b/ipfailover/keepalived/Dockerfile
@@ -5,7 +5,7 @@
 #
 FROM registry.ci.openshift.org/ocp/4.8:base
 
-RUN INSTALL_PKGS="kmod keepalived iproute psmisc nmap-ncat net-tools ipset ipset-libs" && \
+RUN INSTALL_PKGS="kmod keepalived iproute psmisc nmap-ncat net-tools ipset ipset-libs procps-ng" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all

--- a/ipfailover/keepalived/lib/failover-functions.sh
+++ b/ipfailover/keepalived/lib/failover-functions.sh
@@ -34,6 +34,20 @@ function cleanup() {
   exit 0
 }
 
+function unconfigure_failover() {
+  echo "  - Removing ip_vs module ..."
+  modprobe -r ip_vs
+
+  chain="${HA_IPTABLES_CHAIN:-""}"
+  if [[ -n ${chain} ]]; then
+    if iptables -C ${chain} 1 -d 224.0.0.18/32 -j ACCEPT ; then
+      echo "  - Removing keepalived multicast iptables rule ..."
+      iptables -D ${chain} 1 -d 224.0.0.18/32 -j ACCEPT
+    fi
+  fi
+
+  cleanup $(pidof /usr/sbin/keepalived)
+}
 
 function setup_failover() {
   echo "  - Loading ip_vs module ..."

--- a/ipfailover/keepalived/makefile.test
+++ b/ipfailover/keepalived/makefile.test
@@ -9,3 +9,6 @@ test:	image
 
 image:
 	docker build -t $(IMAGE_NAME) .
+
+clean:
+	docker run -it --net=host --privileged=true --entrypoint "/var/lib/ipfailover/keepalived/remove-failover.sh" $(IMAGE_NAME)

--- a/ipfailover/keepalived/remove-failover.sh
+++ b/ipfailover/keepalived/remove-failover.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+#  Includes.
+source "$(dirname "${BASH_SOURCE[0]}")/lib/failover-functions.sh"
+
+echo "`basename $0`: OpenShift IP Failover service terminating."
+unconfigure_failover


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
In order to allow existing customers who are using OpenShift failover feature to different HA implementations, we need to remove all fail over configurations  