### PR TITLE
Bug 2062126: ipfailover: Autodetect the "ens3" NIC

### DIFF
--- a/ipfailover/keepalived/lib/utils.sh
+++ b/ipfailover/keepalived/lib/utils.sh
@@ -3,7 +3,7 @@
 
 #  Constants.
 LIB_DIR=$(dirname "${BASH_SOURCE[0]}")
-VBOX_INTERFACES="enp0s3 enp0s8 eth1"
+VBOX_INTERFACES="enp0s3 enp0s8 eth1 ens3"
 
 
 #


### PR DESCRIPTION
If the user does not specify a network interface, keepalived-ipfailover tries a few default names: "enp0s3", "enp0s8", and "eth1".  If the host uses predictable network interface names as assigned by systemd/udev and the host has a network interface in a PCI Express hotplug slot, then the network interface is given a name of the form "ens3", in which case none of these default names matches it; in this case, before this PR, keepalived-ipfailover would fail to start if the user didn't specify the name explicitly.

To increase the likelihood of success for the defaulting logic on hosts with PCI Express hotplug slots, this PR adds "ens3" to the end of the list of default network interface names that keepalived-ipfailover tries.

Because this PR only changes the defaulting logic and adds to the end of the list of default names, it does not affect the behavior when the user specifies a name or when one of the other default names matches a network interface.

For documentation on predictable network interface names, refer to <https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/>.

* `ipfailover/keepalived/lib/utils.sh` (`VBOX_INTERFACES`): Add "ens3" to the list of names for autodetecting a default network interface when the user does not specify a name.