### PR TITLE
bump RHEL8 egress-dns-proxy image to haproxy26

### DIFF
--- a/egress/dns-proxy/Dockerfile
+++ b/egress/dns-proxy/Dockerfile
@@ -6,7 +6,7 @@
 FROM registry.ci.openshift.org/ocp/4.13:base
 
 # HAProxy 1.6+ version is needed to leverage DNS resolution at runtime.
-RUN INSTALL_PKGS="haproxy22 rsyslog" && \
+RUN INSTALL_PKGS="haproxy26 rsyslog" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
Bumps RHEL8 egress-dns-proxy image to haproxy26 to match what is being
built in dist-git for the rhaos-4.13-rhel-8 brew tag.
