### PR TITLE
rhel9 base image: Fix build failure

### DIFF
--- a/base/Dockerfile.rhel9
+++ b/base/Dockerfile.rhel9
@@ -10,12 +10,10 @@ RUN INSTALL_PKGS=" \
       which tar wget hostname shadow-utils \
       socat findutils lsof bind-utils gzip \
       procps-ng rsync iproute diffutils python3 \
-      " && \
-    if [ ! -e /usr/bin/yum ]; then ln -s /usr/bin/microdnf /usr/bin/yum; fi && \
+      python-unversioned-command" && \
     echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
-    yum install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=False ${INSTALL_PKGS} && \
-    ( test -e /usr/bin/python ||  alternatives --set python /usr/bin/python3 ) && \
-    yum clean all && rm -rf /var/cache/*
+    dnf install -y --nodocs --setopt=install_weak_deps=False ${INSTALL_PKGS} && \
+    dnf clean all && rm -rf /var/cache/*
 
 # Enable x509 common name matching for golang 1.15 and beyond.
 # Enable madvdontneed=1, for golang < 1.16 https://github.com/golang/go/issues/42330


### PR DESCRIPTION
There is a build error, `alternatives` does not understand what to do with python: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=50822467