### PR TITLE
OCPBUGS-10003: Revert "bump RHEL8 egress-dns-proxy image to haproxy26"

### DIFF
--- a/egress/dns-proxy/Dockerfile
+++ b/egress/dns-proxy/Dockerfile
@@ -6,7 +6,7 @@
 FROM registry.ci.openshift.org/ocp/4.13:base
 
 # HAProxy 1.6+ version is needed to leverage DNS resolution at runtime.
-RUN INSTALL_PKGS="haproxy26 rsyslog" && \
+RUN INSTALL_PKGS="haproxy22 rsyslog" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
Reverting from haproxy26 to haproxy22 due to regression finding in OCPBUGS-10003.

`egress/dns-proxy/Dockerfile`: Update to haproxy 22 RPM

**Note**: This will need to be timed with the `rhpkg push` and `rhpkg build`. Once the new haproxy RPM is pushed, then mirrored (takes up to 24 hours), builds for this repo will start failing (haproxy26 rpm will be removed) and this PR will need to be merged.