### PR TITLE
OCPBUGS-11385: Removed chroot setting

### DIFF
--- a/egress/dns-proxy/egress-dns-proxy.sh
+++ b/egress/dns-proxy/egress-dns-proxy.sh
@@ -41,7 +41,6 @@ function generate_haproxy_defaults() {
 global
     log         127.0.0.1 local2
 
-    chroot      /var/lib/haproxy
     pidfile     /var/lib/haproxy/run/haproxy.pid
     maxconn     4000
     user        haproxy


### PR DESCRIPTION
It should fix [OCPBUGS-11385](https://issues.redhat.com/browse/OCPBUGS-11385).

HAProxy `chroot` setting makes little sense when we are already containerized, but it makes the container require to be privileged, which lowers container security too much.