### PR TITLE
OCPBUGS-11595: Revert "[NE-1267] container builds: switch to haproxy26 package"

### DIFF
--- a/egress/dns-proxy/Dockerfile
+++ b/egress/dns-proxy/Dockerfile
@@ -6,7 +6,7 @@
 FROM registry.ci.openshift.org/ocp/4.13:base
 
 # HAProxy 1.6+ version is needed to leverage DNS resolution at runtime.
-RUN INSTALL_PKGS="haproxy26 rsyslog" && \
+RUN INSTALL_PKGS="haproxy22 rsyslog" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
Due to OCPBUGS-11595, revert back to haproxy 22. Haproxy 26 is segfaulting with the CI payload jobs. See [slack thread](https://redhat-internal.slack.com/archives/C01CQA76KMX/p1681136406771139) for more info.

This reverts commit 88c7fae6e2d12ccf9a913ba29fd9f2c952efbb3d.