### PR TITLE
OCPBUGS-29593: Add "max_auto_priority" to keepalived configuration to remove NOTICE from logs

### DIFF
--- a/ipfailover/keepalived/lib/config-generators.sh
+++ b/ipfailover/keepalived/lib/config-generators.sh
@@ -26,7 +26,7 @@ function generate_global_config() {
   local routername ; routername=$(scrub "$1")
 
   echo "global_defs {"
-  echo "   notification_email {"
+  echo "   max_auto_priority    99"
 
   for email in ${ADMIN_EMAILS[@]}; do
     echo "     $email"

--- a/ipfailover/keepalived/lib/config-generators.sh
+++ b/ipfailover/keepalived/lib/config-generators.sh
@@ -27,6 +27,7 @@ function generate_global_config() {
 
   echo "global_defs {"
   echo "   max_auto_priority    99"
+  echo "   notification_email {"
 
   for email in ${ADMIN_EMAILS[@]}; do
     echo "     $email"


### PR DESCRIPTION
Should be explicitly set to the default of  99. THe following message appears in logs:

```
- Loading ip_vs module ...
- Checking if ip_vs module is available ...
ip_vs 172032 0
- Module ip_vs is loaded.
- check for iptables rule for keepalived multicast (224.0.0.18) ...
- Generating and writing config to /etc/keepalived/keepalived.conf
- Starting failover services ...
Sun Feb 11 14:55:44 2024: Starting Keepalived v2.1.5 (07/13,2020)
Sun Feb 11 14:55:44 2024: Running on Linux 4.18.0-372.80.1.el8_6.x86_64 #1 SMP Fri Nov 3 14:30:16 EDT 2023 (built for Linux 4.18.0)
Sun Feb 11 14:55:44 2024: Command line: '/usr/sbin/keepalived' '-n' '--log-console'
Sun Feb 11 14:55:44 2024: Opening file '/etc/keepalived/keepalived.conf'.
Sun Feb 11 14:55:44 2024: NOTICE: setting config option max_auto_priority should result in better keepalived performance
Sun Feb 11 14:55:44 2024: Starting VRRP child process, pid=99
Sun Feb 11 14:55:44 2024: Registering Kernel netlink reflector
Sun Feb 11 14:55:44 2024: Registering Kernel netlink command channel
Sun Feb 11 14:55:44 2024: Opening file '/etc/keepalived/keepalived.conf'.
Sun Feb 11 14:55:44 2024: WARNING - default user 'keepalived_script' for script execution does not exist - please create.
Sun Feb 11 14:55:44 2024: SECURITY VIOLATION - scripts are being executed but script_security not enabled.
``` 