### PR TITLE
Allow egress-http-proxy.sh to be run as non-root

### DIFF
--- a/egress/http-proxy/egress-http-proxy.sh
+++ b/egress/http-proxy/egress-http-proxy.sh
@@ -91,4 +91,4 @@ sed -e 's/^/  /' ${CONF}
 echo ""
 echo ""
 
-exec squid -N -f /tmp/squid.conf
+exec squid -N -f ${CONF}

--- a/egress/http-proxy/egress-http-proxy.sh
+++ b/egress/http-proxy/egress-http-proxy.sh
@@ -72,7 +72,7 @@ if [[ "${EGRESS_HTTP_PROXY_MODE:-}" == "unit-test" ]]; then
     exit 0
 fi
 
-CONF=/etc/squid/squid.conf
+CONF=/tmp/squid.conf
 rm -f ${CONF}
 
 cat > ${CONF} <<EOF
@@ -81,6 +81,7 @@ cache deny all
 access_log none all
 debug_options ALL,0
 shutdown_lifetime 0
+pid_filename none
 EOF
 
 generate_acls >> ${CONF}
@@ -90,4 +91,4 @@ sed -e 's/^/  /' ${CONF}
 echo ""
 echo ""
 
-exec squid -N
+exec squid -N -f /tmp/squid.conf

--- a/egress/http-proxy/egress-http-proxy.sh
+++ b/egress/http-proxy/egress-http-proxy.sh
@@ -73,9 +73,9 @@ if [[ "${EGRESS_HTTP_PROXY_MODE:-}" == "unit-test" ]]; then
 fi
 
 CONF=/tmp/squid.conf
-rm -f ${CONF}
+rm -f "${CONF}"
 
-cat > ${CONF} <<EOF
+cat > "${CONF}" <<EOF
 http_port 8080
 cache deny all
 access_log none all
@@ -84,11 +84,11 @@ shutdown_lifetime 0
 pid_filename none
 EOF
 
-generate_acls >> ${CONF}
+generate_acls >> "${CONF}"
 
 echo "Running squid with config:"
-sed -e 's/^/  /' ${CONF}
+sed -e 's/^/  /' "${CONF}"
 echo ""
 echo ""
 
-exec squid -N -f ${CONF}
+exec squid -N -f "${CONF}"


### PR DESCRIPTION
I'd like to be able to deploy this image without running as root.

The necessary changes are quite simple:

 * Generate squid.conf in a writable location (`/tmp`)  
 * Disable pidfile creation