### PR TITLE
[release-4.15] OCPBUGS-30413: update unit tests in egress/dns-proxy

### DIFF
--- a/egress/dns-proxy/egress_dns_proxy_test.go
+++ b/egress/dns-proxy/egress_dns_proxy_test.go
@@ -278,7 +278,6 @@ func TestHAProxyDefaults(t *testing.T) {
 global
     log         127.0.0.1 local2
 
-    chroot      /var/lib/haproxy
     pidfile     /var/lib/haproxy/run/haproxy.pid
     maxconn     4000
     user        haproxy

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/openshift/images
+
+go 1.20


### PR DESCRIPTION
This is an manual cherry-pick of https://github.com/openshift/images/pull/165. 

This is the same change as #165 except we set the version of Go in `go.mod` to 1.20 to match the expectations of OCP 4.15.

CI enabled by https://github.com/openshift/release/pull/51358.
