### PR TITLE
OCPBUGS-24850: Bump OpenShift 4.16, RHEL9, and iptables package

### DIFF
--- a/egress/router/Dockerfile
+++ b/egress/router/Dockerfile
@@ -3,9 +3,9 @@
 #
 # The standard name for this image is openshift/origin-egress-router
 
-FROM registry.ci.openshift.org/ocp/4.15:base
+FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
 
-RUN INSTALL_PKGS="iproute iputils iptables" && \
+RUN INSTALL_PKGS="iproute iputils iptables-nft" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all


### PR DESCRIPTION
Bump OpenShift 4.16, RHEL9, and replace iptables package with iptables-nft package for RHEL9

Replaces #157 