### PR TITLE
Add dnf-plugins-core in scos to help with OCP image compat

### DIFF
--- a/base/Dockerfile.rhel9
+++ b/base/Dockerfile.rhel9
@@ -17,10 +17,9 @@ RUN INSTALL_PKGS=" \
 
 # OKD-specific changes
 RUN source /etc/os-release && [ "${ID}" != "centos" ] && exit 0; \
-    INSTALL_PKGS="centos-release-nfv-openvswitch centos-release-openstack-zed" && \
-        # Enable the [rt] repository (with no need to install dnf-plugins-core)
-        sed -i '/^\[rt\]/,/^$/s/enabled=0/enabled=1/' /etc/yum.repos.d/*.repo && \
+    INSTALL_PKGS="dnf-plugins-core centos-release-nfv-openvswitch centos-release-openstack-zed" && \
         dnf install -y --nodocs --setopt=install_weak_deps=False ${INSTALL_PKGS} && \
+        dnf config-manager --set-enabled rt && \
         dnf clean all && rm -rf /var/cache/*
 
 # Enable x509 common name matching for golang 1.15 and beyond.


### PR DESCRIPTION
openshift/driver-toolkit assumes this plugin for `config-manager` . Probably easiest to enable it for everyone.