### PR TITLE
OKD-40: Remove centos-openstack-zed and add in rdo repo to get python-cinderclient dependency

### DIFF
--- a/base/Dockerfile.rhel9
+++ b/base/Dockerfile.rhel9
@@ -17,10 +17,12 @@ RUN INSTALL_PKGS=" \
 
 # OKD-specific changes
 RUN source /etc/os-release && [ "${ID}" != "centos" ] && exit 0; \
-    INSTALL_PKGS="dnf-plugins-core centos-release-nfv-openvswitch centos-release-openstack-zed" && \
+    INSTALL_PKGS="dnf-plugins-core centos-release-nfv-openvswitch" && \
         dnf install -y --nodocs --setopt=install_weak_deps=False ${INSTALL_PKGS} && \
         dnf config-manager --set-enabled rt && \
-        dnf clean all && rm -rf /var/cache/*
+        dnf clean all && rm -rf /var/cache/* && \
+    curl -o /etc/yum.repos.d/delorean.repo https://trunk.rdoproject.org/centos9-master/puppet-passed-ci/delorean.repo && \
+    curl -o /etc/yum.repos.d/delorean-deps.repo https://trunk.rdoproject.org/centos9-master/delorean-deps.repo;
 
 # Enable x509 common name matching for golang 1.15 and beyond.
 # Enable madvdontneed=1, for golang < 1.16 https://github.com/golang/go/issues/42330


### PR DESCRIPTION
The centos-openstack-zed package fails with a dependency on rabbitmq - the mirrorlist url returns a 404.
```
CentOS-9 - RabbitMQ 38                          135 kB/s | 124 kB     00:00
Errors during downloading metadata for repository 'centos-rabbitmq-38':
  - Status code: 404 for https://mirrors.centos.org/metalink?repo=centos-messaging-sig-rabbitmq-38--stream&arch=x86_64&protocol=https,http (IP: 67.219.144.68)
```
Add in the rdo repos which provide the python dependency instead