### PR TITLE
NO-JIRA: egress: update OWNERS

### DIFF
--- a/egress/OWNERS
+++ b/egress/OWNERS
@@ -6,6 +6,8 @@ approvers:
   - rfredette
   - gcs278
   - alebedev87
+  - Thealisyed
+  - grzpiotrowski
 reviewers:
   - knobunc
   - Miciah
@@ -14,4 +16,6 @@ reviewers:
   - rfredette
   - gcs278
   - alebedev87
+  - Thealisyed
+  - grzpiotrowski
 component: Routing


### PR DESCRIPTION
- `egress/OWNERS`: Add `Thealisyed` and `grzpiotrowski` to the approvers and reviewers

Both are members of the Network Ingress/DNS team maintaining this component.