### PR TITLE
OCPBUGS-48318: Change default value for OPENSHIFT_HA_VRRP_ID_OFFSET

### DIFF
--- a/ipfailover/keepalived/conf/settings.sh
+++ b/ipfailover/keepalived/conf/settings.sh
@@ -38,10 +38,10 @@ HA_REPLICA_COUNT="${OPENSHIFT_HA_REPLICA_COUNT:-"1"}"
 
 #  Offset value to use to set the virtual router ids. Using different offset
 #  values allows multiple ipfailover configurations to exist within the
-#  same cluster. Range 1..255
+#  same cluster. Range 0..254
 #     HA_VRRP_ID_OFFSET=30
 #
-HA_VRRP_ID_OFFSET="${OPENSHIFT_HA_VRRP_ID_OFFSET:-"0"}"
+HA_VRRP_ID_OFFSET="${OPENSHIFT_HA_VRRP_ID_OFFSET:-"10"}"
 
 # When the DC supplies an (non null) iptables chain
 # (OPENSHIFT_HA_IPTABLES_CHAIN) make sure the rule to pass keepalived

--- a/ipfailover/keepalived/lib/config-generators.sh
+++ b/ipfailover/keepalived/lib/config-generators.sh
@@ -188,7 +188,7 @@ function generate_vrrpd_instance_config() {
 
   local vipname ; vipname=$(scrub "$1")
   local initialstate=""
-  local vrrpidoffset=${HA_VRRP_ID_OFFSET:-0}
+  local vrrpidoffset=${HA_VRRP_ID_OFFSET:-10}
   local excludedvrrpids=( $HA_EXCLUDED_VRRP_IDS )
 
   new_vrrp_id=$((vrrpidoffset + iid))


### PR DESCRIPTION
Changes the default value for OPENSHIFT_HA_VRRP_ID_OFFSET to 10 instead of zero. This will help prevent collisions with VRRP advertisements that are using the same VRID.