### PR TITLE
OCPSTRAT-3113: Set DEFAULT:PQ crypto-policies to RHEL9 base image

### DIFF
--- a/base/Dockerfile.rhel9
+++ b/base/Dockerfile.rhel9
@@ -1,4 +1,15 @@
+# Builder stage: Configure crypto-policies with post-quantum support
+FROM registry.ci.openshift.org/ocp/4.22:base-rhel9 AS builder
+
+RUN dnf install -y --nodocs crypto-policies-scripts && \
+    update-crypto-policies --set DEFAULT:PQ && \
+    dnf clean all && rm -rf /var/cache/*
+
+# Final stage: Base RHEL9 image with PQ crypto-policies
 FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+
+# Copy crypto-policies configuration from builder stage
+COPY --from=builder /etc/crypto-policies/ /etc/crypto-policies/
 
 # A ubi9 image will expose python3 as /usr/bin/python. It does not contain
 # python2. Subsequent layers should install if it needed.


### PR DESCRIPTION
## Summary

- Convert base/Dockerfile.rhel9 to multi-stage build to add post-quantum cryptography support
- Builder stage installs crypto-policies and configures DEFAULT:PQ policy
- Final stage copies /etc/crypto-policies/ configuration from builder
- Enables post-quantum cryptography for future-proofing against quantum computing threats

## Technical Details

The DEFAULT:PQ policy is additive - it adds post-quantum algorithms while maintaining existing algorithms for backward compatibility.

## Test plan

- [x] Build the image successfully: `docker build -f base/Dockerfile.rhel9 .`
- [x] Verify crypto-policies configuration: `docker run --rm <image> update-crypto-policies --show` (should output: DEFAULT:PQ)
- [x] Verify policy files exist: `docker run --rm <image> ls -la /etc/crypto-policies/`
- [ ] Test downstream images build successfully (egress router, dns-proxy, http-proxy, ipfailover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)