### PR TITLE
OCPBUGS-84344: yum.conf: omit docs, weak deps

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -13,6 +13,8 @@ RUN INSTALL_PKGS=" \
       iproute \
       " && \
     echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
+    echo 'install_weak_deps=0' >> /etc/yum.conf && \
+    echo 'tsflags=nodocs' >> /etc/yum.conf && \
     yum install -y ${INSTALL_PKGS} && \
     yum clean all && \
     mkdir -p /var/lib/origin

--- a/base/Dockerfile.centos7
+++ b/base/Dockerfile.centos7
@@ -12,6 +12,8 @@ RUN INSTALL_PKGS=" \
       iproute \
       " && \
     echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
+    echo 'install_weak_deps=0' >> /etc/yum.conf && \
+    echo 'tsflags=nodocs' >> /etc/yum.conf && \
     yum install -y ${INSTALL_PKGS} && \
     yum clean all && \
     mkdir -p /var/lib/origin

--- a/base/Dockerfile.rhel
+++ b/base/Dockerfile.rhel
@@ -15,7 +15,9 @@ RUN INSTALL_PKGS=" \
       " && \
     if [ ! -e /usr/bin/yum ]; then ln -s /usr/bin/microdnf /usr/bin/yum; fi && \
     echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
-    yum install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=False ${INSTALL_PKGS} && \
+    echo 'install_weak_deps=0' >> /etc/yum.conf && \
+    echo 'tsflags=nodocs' >> /etc/yum.conf && \
+    yum install -y ${INSTALL_PKGS} && \
     ( test -e /usr/bin/python ||  alternatives --set python /usr/bin/python3 ) && \
     yum clean all && rm -rf /var/cache/*
 

--- a/base/Dockerfile.rhel7
+++ b/base/Dockerfile.rhel7
@@ -12,6 +12,8 @@ RUN INSTALL_PKGS=" \
       iproute \
       " && \
     echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
+    echo 'install_weak_deps=0' >> /etc/yum.conf && \
+    echo 'tsflags=nodocs' >> /etc/yum.conf && \
     yum --disablerepo=origin-local-release install -y $INSTALL_PKGS && \
     yum clean all && \
     mkdir -p /var/lib/origin

--- a/base/Dockerfile.rhel9
+++ b/base/Dockerfile.rhel9
@@ -13,21 +13,22 @@ RUN INSTALL_PKGS=" \
       python-unversioned-command util-linux" && \
     echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
     echo 'install_weak_deps=0' >> /etc/yum.conf && \
-    dnf install -y --nodocs ${INSTALL_PKGS} && \
+    echo 'tsflags=nodocs' >> /etc/yum.conf && \
+    dnf install -y ${INSTALL_PKGS} && \
     dnf clean all && rm -rf /var/cache/*
 
 # OKD-specific changes
 RUN source /etc/os-release && [ "${ID}" != "centos" ] && exit 0; \
     INSTALL_PKGS="dnf-plugins-core centos-release-nfv-openvswitch" && \
     [ "${VERSION_ID}" = "9" ] && INSTALL_PKGS="${INSTALL_PKGS} centos-release-openstack-zed"; \
-    dnf install -y --nodocs --setopt=install_weak_deps=False ${INSTALL_PKGS} && \
+    dnf install -y ${INSTALL_PKGS} && \
         dnf config-manager --set-enabled rt && \
         dnf clean all && rm -rf /var/cache/*; \
     [ "${VERSION_ID}" = "10" ] && \
         curl -o /etc/yum.repos.d/delorean.repo https://trunk.rdoproject.org/centos10-master/podified-ci-testing/delorean.repo && \
         curl -o /etc/yum.repos.d/delorean-deps.repo https://trunk.rdoproject.org/centos10-master/delorean-deps.repo && \
         # gpgme removed from ubi10-minimal, was in ubi9-minimal required by all builds with github.com/proglottis/gpgme
-        dnf install -y --nodocs --setopt=install_weak_deps=False gpgme && \
+        dnf install -y gpgme && \
         dnf clean all && rm -rf /var/cache/* || true
 
 # Enable x509 common name matching for golang 1.15 and beyond.


### PR DESCRIPTION
Example, machine-config-operator has 1786 files that are listed as docs and only 670 of those come from the true base image.

```
~ podman run -it --entrypoint /usr/bin/rpm registry.redhat.io/rhel9-6-els/rhel-minimal -qad | wc -l
670
~ podman run -it --entrypoint /usr/bin/rpm `oc adm release info 4.22.0-rc.0 --image-for machine-config-operator` -qad | wc -l
1786
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized container builds to omit package documentation, producing smaller images and faster deployments.
  * Disabled installation of weak/optional package dependencies to further reduce image size and unnecessary packages.
  * Preserved existing package selection and cleanup behavior while applying these build-time optimizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->