### PR TITLE
Revert "OCPBUGS-84344: yum.conf: omit docs, weak deps"

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -13,8 +13,6 @@ RUN INSTALL_PKGS=" \
       iproute \
       " && \
     echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
-    echo 'install_weak_deps=0' >> /etc/yum.conf && \
-    echo 'tsflags=nodocs' >> /etc/yum.conf && \
     yum install -y ${INSTALL_PKGS} && \
     yum clean all && \
     mkdir -p /var/lib/origin

--- a/base/Dockerfile.centos7
+++ b/base/Dockerfile.centos7
@@ -12,8 +12,6 @@ RUN INSTALL_PKGS=" \
       iproute \
       " && \
     echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
-    echo 'install_weak_deps=0' >> /etc/yum.conf && \
-    echo 'tsflags=nodocs' >> /etc/yum.conf && \
     yum install -y ${INSTALL_PKGS} && \
     yum clean all && \
     mkdir -p /var/lib/origin

--- a/base/Dockerfile.rhel
+++ b/base/Dockerfile.rhel
@@ -15,9 +15,7 @@ RUN INSTALL_PKGS=" \
       " && \
     if [ ! -e /usr/bin/yum ]; then ln -s /usr/bin/microdnf /usr/bin/yum; fi && \
     echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
-    echo 'install_weak_deps=0' >> /etc/yum.conf && \
-    echo 'tsflags=nodocs' >> /etc/yum.conf && \
-    yum install -y ${INSTALL_PKGS} && \
+    yum install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=False ${INSTALL_PKGS} && \
     ( test -e /usr/bin/python ||  alternatives --set python /usr/bin/python3 ) && \
     yum clean all && rm -rf /var/cache/*
 

--- a/base/Dockerfile.rhel7
+++ b/base/Dockerfile.rhel7
@@ -12,8 +12,6 @@ RUN INSTALL_PKGS=" \
       iproute \
       " && \
     echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
-    echo 'install_weak_deps=0' >> /etc/yum.conf && \
-    echo 'tsflags=nodocs' >> /etc/yum.conf && \
     yum --disablerepo=origin-local-release install -y $INSTALL_PKGS && \
     yum clean all && \
     mkdir -p /var/lib/origin

--- a/base/Dockerfile.rhel9
+++ b/base/Dockerfile.rhel9
@@ -13,22 +13,21 @@ RUN INSTALL_PKGS=" \
       python-unversioned-command util-linux" && \
     echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
     echo 'install_weak_deps=0' >> /etc/yum.conf && \
-    echo 'tsflags=nodocs' >> /etc/yum.conf && \
-    dnf install -y ${INSTALL_PKGS} && \
+    dnf install -y --nodocs ${INSTALL_PKGS} && \
     dnf clean all && rm -rf /var/cache/*
 
 # OKD-specific changes
 RUN source /etc/os-release && [ "${ID}" != "centos" ] && exit 0; \
     INSTALL_PKGS="dnf-plugins-core centos-release-nfv-openvswitch" && \
     [ "${VERSION_ID}" = "9" ] && INSTALL_PKGS="${INSTALL_PKGS} centos-release-openstack-zed"; \
-    dnf install -y ${INSTALL_PKGS} && \
+    dnf install -y --nodocs --setopt=install_weak_deps=False ${INSTALL_PKGS} && \
         dnf config-manager --set-enabled rt && \
         dnf clean all && rm -rf /var/cache/*; \
     [ "${VERSION_ID}" = "10" ] && \
         curl -o /etc/yum.repos.d/delorean.repo https://trunk.rdoproject.org/centos10-master/podified-ci-testing/delorean.repo && \
         curl -o /etc/yum.repos.d/delorean-deps.repo https://trunk.rdoproject.org/centos10-master/delorean-deps.repo && \
         # gpgme removed from ubi10-minimal, was in ubi9-minimal required by all builds with github.com/proglottis/gpgme
-        dnf install -y gpgme && \
+        dnf install -y --nodocs --setopt=install_weak_deps=False gpgme && \
         dnf clean all && rm -rf /var/cache/* || true
 
 # Enable x509 common name matching for golang 1.15 and beyond.


### PR DESCRIPTION
Reverts openshift/images#231

It turns out that microdnf does not properly read these values. I'll see if we can update the microdnf wrapper to inset the flags for all invocations that lack it currently. Since this actually causes a regression we'll revert this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base image package installation configurations across multiple image variants to optimize build processes and streamline dependency handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->