### PR TITLE
NE-2715: Update keepalived-ipfailover to replace iptables with nftables

### DIFF
--- a/ipfailover/keepalived/Dockerfile
+++ b/ipfailover/keepalived/Dockerfile
@@ -5,18 +5,11 @@
 #
 FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
 
-RUN INSTALL_PKGS="kmod keepalived iproute psmisc nmap-ncat net-tools ipset ipset-libs procps-ng" && \
+RUN INSTALL_PKGS="kmod keepalived iproute psmisc nmap-ncat net-tools ipset ipset-libs procps-ng nftables" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all
 COPY . /var/lib/ipfailover/keepalived/
-
-COPY iptables-scripts/iptables /usr/sbin/
-COPY iptables-scripts/iptables-save /usr/sbin/
-COPY iptables-scripts/iptables-restore /usr/sbin/
-COPY iptables-scripts/ip6tables /usr/sbin/
-COPY iptables-scripts/ip6tables-save /usr/sbin/
-COPY iptables-scripts/ip6tables-restore /usr/sbin/
 
 LABEL io.k8s.display-name="OpenShift IP Failover" \
       io.k8s.description="This is a component of OpenShift and runs a clustered keepalived instance across multiple hosts to allow highly available IP addresses." \

--- a/ipfailover/keepalived/conf/settings.sh
+++ b/ipfailover/keepalived/conf/settings.sh
@@ -43,10 +43,14 @@ HA_REPLICA_COUNT="${OPENSHIFT_HA_REPLICA_COUNT:-"1"}"
 #
 HA_VRRP_ID_OFFSET="${OPENSHIFT_HA_VRRP_ID_OFFSET:-"0"}"
 
-# When the DC supplies an (non null) iptables chain
-# (OPENSHIFT_HA_IPTABLES_CHAIN) make sure the rule to pass keepalived
-# multicast (224.0.0.18) traffic is in the table.
-HA_IPTABLES_CHAIN="${OPENSHIFT_HA_IPTABLES_CHAIN:-""}"
+# When set (non-empty), nftables rules are created to allow keepalived
+# multicast (224.0.0.18) traffic. Only the non-emptiness of the value
+# matters; nft manages its own isolated table and chain.
+#
+# OPENSHIFT_HA_NFTABLES_RULE is the preferred env var name.
+# OPENSHIFT_HA_IPTABLES_CHAIN is accepted for backward compatibility
+# with existing deployments but is deprecated.
+HA_MULTICAST_ACCEPT="${OPENSHIFT_HA_NFTABLES_RULE:-${OPENSHIFT_HA_IPTABLES_CHAIN:-""}}"
 
 # Optional external check script that is run every HA_CHECK_INTERVAL seconds
 # The script can test whatever is needed to verify the application is running.

--- a/ipfailover/keepalived/iptables-scripts/ip6tables
+++ b/ipfailover/keepalived/iptables-scripts/ip6tables
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host /usr/sbin/ip6tables "$@"

--- a/ipfailover/keepalived/iptables-scripts/ip6tables-restore
+++ b/ipfailover/keepalived/iptables-scripts/ip6tables-restore
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host /usr/sbin/ip6tables-restore "$@"

--- a/ipfailover/keepalived/iptables-scripts/ip6tables-save
+++ b/ipfailover/keepalived/iptables-scripts/ip6tables-save
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host /usr/sbin/ip6tables-save "$@"

--- a/ipfailover/keepalived/iptables-scripts/iptables
+++ b/ipfailover/keepalived/iptables-scripts/iptables
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host /usr/sbin/iptables "$@"

--- a/ipfailover/keepalived/iptables-scripts/iptables-restore
+++ b/ipfailover/keepalived/iptables-scripts/iptables-restore
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host /usr/sbin/iptables-restore "$@"

--- a/ipfailover/keepalived/iptables-scripts/iptables-save
+++ b/ipfailover/keepalived/iptables-scripts/iptables-save
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host /usr/sbin/iptables-save "$@"

--- a/ipfailover/keepalived/lib/failover-functions.sh
+++ b/ipfailover/keepalived/lib/failover-functions.sh
@@ -38,11 +38,14 @@ function unconfigure_failover() {
   echo "  - Removing ip_vs module ..."
   modprobe -r ip_vs
 
-  chain="${HA_IPTABLES_CHAIN:-""}"
-  if [[ -n ${chain} ]]; then
-    if iptables -C ${chain} 1 -d 224.0.0.18/32 -j ACCEPT ; then
-      echo "  - Removing keepalived multicast iptables rule ..."
-      iptables -D ${chain} 1 -d 224.0.0.18/32 -j ACCEPT
+  # Remove the nftables table we created for keepalived multicast.
+  # Unlike iptables where we removed a single rule from a shared chain,
+  # nft gives us an isolated table ("inet keepalived") that only we own,
+  # so deleting the entire table is the correct cleanup.
+  if [[ -n "${HA_MULTICAST_ACCEPT:-}" ]]; then
+    if nft list table inet keepalived > /dev/null 2>&1 ; then
+      echo "  - Removing keepalived multicast nftables rules ..."
+      nft delete table inet keepalived
     fi
   fi
 
@@ -60,16 +63,31 @@ function setup_failover() {
     echo "ERROR: Module ip_vs is NOT available."
   fi
 
-  # When the DC supplies an (non null) iptables chain
-  # (OPENSHIFT_HA_IPTABLES_CHAIN) make sure the rule to pass keepalived
-  # multicast (224.0.0.18) traffic is in the table.
-  chain="${HA_IPTABLES_CHAIN:-""}"
-  if [[ -n ${chain} ]]; then
-    echo "  - check for iptables rule for keepalived multicast (224.0.0.18) ..."
-    if ! iptables -S | grep 224.0.0.18 > /dev/null 2>&1 ; then
-      # Add the rule to the beginning of the chain.
-      echo "  - adding iptables rule to $chain to access 224.0.0.18."
-      iptables -I ${chain} 1 -d 224.0.0.18/32 -j ACCEPT
+  # When HA_MULTICAST_ACCEPT is set, ensure an nftables rule exists to
+  # explicitly allow VRRP multicast traffic (224.0.0.18) used by keepalived.
+  # The chain policy is "accept" so this rule is defense-in-depth, not
+  # load-bearing — traffic would flow without it, but we keep it as an
+  # explicit signal that multicast is expected.
+  #
+  # nft creates an isolated table ("inet keepalived") with its own chain
+  # hooked into the input path. This is different from iptables where we
+  # inserted a rule into an existing shared chain. The table name is fixed
+  # and does not come from the env var value.
+  if [[ -n "${HA_MULTICAST_ACCEPT:-}" ]]; then
+    echo "  - Ensuring nftables rule for keepalived multicast (224.0.0.18) ..."
+    if ! nft list chain inet keepalived filter 2>/dev/null | grep -q 'ip daddr 224.0.0.18 accept' ; then
+      echo "  - Adding nftables rule to accept multicast 224.0.0.18."
+      # Atomic batch: create the table, chain, and rule in one nft -f call.
+      # "inet" family handles both IPv4 and IPv6.
+      # Hook "input" at priority 0 matches where the old iptables rule lived.
+      nft -f - <<-'NFT'
+	table inet keepalived {
+	  chain filter {
+	    type filter hook input priority 0; policy accept;
+	    ip daddr 224.0.0.18 accept
+	  }
+	}
+	NFT
     fi
   fi
 


### PR DESCRIPTION
## Summary

- Replace all iptables usage in keepalived-ipfailover with native nft commands
- Remove `iptables-scripts/` chroot wrappers (no longer needed since nft runs directly in the container)
- Install `nftables` package in container image
- Create a dedicated `inet keepalived` nft table for the VRRP multicast accept rule (224.0.0.18)
- Preserve `OPENSHIFT_HA_IPTABLES_CHAIN` env var for backward compatibility

## Why

iptables is deprecated in RHEL 9 and the `ip_tables` kernel module is [removed in RHEL 10](https://github.com/moby/moby/issues/49020). The `iptables-nft` userspace shim [remains but is deprecated](https://access.redhat.com/solutions/6739041). This migrates to native nft before the shim is removed entirely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Refactor**
  * Migrated keepalived multicast firewall handling from iptables to nftables for better long-term compatibility.
  * Updated multicast acceptance behavior to rely on an nftables ruleset when the new multicast configuration is provided (the prior iptables-based setting is still recognized for compatibility).
  * Removed legacy iptables wrapper scripts that are no longer needed with the nftables-based approach.
  * Added nftables to the container image to support the updated firewall management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->