### PR TITLE
ART-19728: Add Dockerfile.rhel10

### DIFF
--- a/base/Dockerfile.rhel10
+++ b/base/Dockerfile.rhel10
@@ -2,7 +2,7 @@
 FROM registry.ci.openshift.org/ocp/5.0:base-rhel10 AS builder
 
 RUN dnf install -y --nodocs crypto-policies-scripts && \
-    update-crypto-policies --set DEFAULT:PQ && \
+    update-crypto-policies --show && \
     dnf clean all && rm -rf /var/cache/*
 
 # Final stage: Base RHEL10 image with PQ crypto-policies

--- a/base/Dockerfile.rhel10
+++ b/base/Dockerfile.rhel10
@@ -16,7 +16,6 @@ RUN INSTALL_PKGS=" \
     dnf install -y --nodocs ${INSTALL_PKGS} && \
     dnf clean all && rm -rf /var/cache/*
 
-ENV GODEBUG=x509ignoreCN=0,madvdontneed=1
 
 LABEL io.k8s.display-name="OpenShift Base RHEL10" \
       io.k8s.description="This is the base image from which all OpenShift RHEL10 images inherit."

--- a/base/Dockerfile.rhel10
+++ b/base/Dockerfile.rhel10
@@ -1,11 +1,3 @@
-# Builder stage: Configure crypto-policies with post-quantum support
-FROM registry.ci.openshift.org/ocp/5.0:base-rhel10 AS builder
-
-RUN dnf install -y --nodocs crypto-policies-scripts && \
-    update-crypto-policies --show && \
-    dnf clean all && rm -rf /var/cache/*
-
-# Final stage: Base RHEL10 image with PQ crypto-policies
 FROM registry.ci.openshift.org/ocp/5.0:base-rhel10
 
 # Copy crypto-policies configuration from builder stage

--- a/base/Dockerfile.rhel10
+++ b/base/Dockerfile.rhel10
@@ -1,7 +1,5 @@
 FROM registry.ci.openshift.org/ocp/5.0:base-rhel10
 
-# Copy crypto-policies configuration from builder stage
-COPY --from=builder /etc/crypto-policies/ /etc/crypto-policies/
 
 # A ubi10 image will expose python3 as /usr/bin/python. It does not contain
 # python2. Subsequent layers should install if it needed.

--- a/base/Dockerfile.rhel10
+++ b/base/Dockerfile.rhel10
@@ -1,0 +1,33 @@
+# Builder stage: Configure crypto-policies with post-quantum support
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel10 AS builder
+
+RUN dnf install -y --nodocs crypto-policies-scripts && \
+    update-crypto-policies --set DEFAULT:PQ && \
+    dnf clean all && rm -rf /var/cache/*
+
+# Final stage: Base RHEL10 image with PQ crypto-policies
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel10
+
+# Copy crypto-policies configuration from builder stage
+COPY --from=builder /etc/crypto-policies/ /etc/crypto-policies/
+
+# A ubi10 image will expose python3 as /usr/bin/python. It does not contain
+# python2. Subsequent layers should install if it needed.
+#
+# Set install_weak_deps=False to avoid libmaxminddb from pulling in the
+# very large geolite databases.
+
+RUN INSTALL_PKGS=" \
+      which tar wget hostname shadow-utils \
+      socat findutils lsof bind-utils gzip \
+      procps-ng rsync iproute diffutils python3 \
+      python-unversioned-command util-linux gpgme" && \
+    echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
+    echo 'install_weak_deps=0' >> /etc/yum.conf && \
+    dnf install -y --nodocs ${INSTALL_PKGS} && \
+    dnf clean all && rm -rf /var/cache/*
+
+ENV GODEBUG=x509ignoreCN=0,madvdontneed=1
+
+LABEL io.k8s.display-name="OpenShift Base RHEL10" \
+      io.k8s.description="This is the base image from which all OpenShift RHEL10 images inherit."

--- a/base/Dockerfile.rhel10
+++ b/base/Dockerfile.rhel10
@@ -1,6 +1,5 @@
 FROM registry.ci.openshift.org/ocp/5.0:base-rhel10
 
-
 # A ubi10 image will expose python3 as /usr/bin/python. It does not contain
 # python2. Subsequent layers should install if it needed.
 #


### PR DESCRIPTION
## Summary
- Add new Dockerfile.rhel10 for RHEL 10 base image support
- Based on RHEL9 Dockerfile with adaptations for RHEL10
- Includes gpgme package (removed from ubi10-minimal)
- Simplified for RHEL10 (removed post-quantum crypto-policies from RHEL9)

## Changes
- New file: base/Dockerfile.rhel10
- Uses registry.ci.openshift.org/ocp/5.0:base-rhel10 as base image
- Core package set consistent with RHEL9
- Added gpgme to main package list for RHEL10 compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added base container image configuration for RHEL 10 with Python 3 support, optimized package management, and system-level configuration for OpenShift deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->