### PR TITLE
NO-JIRA: Update ipfailover/OWNERS to reflect current NID team

### DIFF
--- a/ipfailover/OWNERS
+++ b/ipfailover/OWNERS
@@ -1,26 +1,33 @@
-reviewers:
-  - pecameron
-  - smarterclayton
-  - pweil-
-  - knobunc
-  - ironcladlou
-  - Miciah
-  - frobware
-  - danehans
-  - sgreene570
-  - candita
 approvers:
-  - smarterclayton
-  - pweil-
   - knobunc
-  - ironcladlou
-  - danwinship
-  - rajatchopra
-  - pravisankar
-  - dcbw
   - Miciah
-  - frobware
-  - danehans
-  - sgreene570
   - candita
+  - rfredette
+  - alebedev87
+  - gcs278
+  - Thealisyed
+  - grzpiotrowski
+  - rikatz
+  - davidesalerno
+  - bentito
+  - jcmoraisjr
+  - aswinsuryan
+  - melvinjoseph86
+  - rhamini3
+reviewers:
+  - knobunc
+  - Miciah
+  - candita
+  - rfredette
+  - alebedev87
+  - gcs278
+  - Thealisyed
+  - grzpiotrowski
+  - rikatz
+  - davidesalerno
+  - bentito
+  - jcmoraisjr
+  - aswinsuryan
+  - melvinjoseph86
+  - rhamini3
 component: Routing


### PR DESCRIPTION
## Summary

- Sync ipfailover/OWNERS approvers and reviewers with the current NID team roster
- Matches the current [cluster-ingress-operator OWNERS](https://github.com/openshift/cluster-ingress-operator/blob/master/OWNERS) file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refreshed the project’s internal review and approval roster with an updated ordered set of approvers and reviewers.
  * Adjusted the ordering of entries so approvers are listed before reviewers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->