### PR TITLE
ART-20722: Skip PQ crypto-policies setup for CentOS/OKD builds

### DIFF
--- a/base/Dockerfile.rhel9
+++ b/base/Dockerfile.rhel9
@@ -1,14 +1,17 @@
 # Builder stage: Configure crypto-policies with post-quantum support
+# Skip PQ crypto-policies for CentOS (OKD) builds - the PQ module is not available
 FROM registry.ci.openshift.org/ocp/5.0:base-rhel9 AS builder
 
-RUN dnf install -y --nodocs crypto-policies-scripts && \
-    update-crypto-policies --set DEFAULT:PQ && \
-    dnf clean all && rm -rf /var/cache/*
+RUN source /etc/os-release && [ "${ID}" = "centos" ] || \
+    (dnf install -y --nodocs crypto-policies-scripts && \
+     update-crypto-policies --set DEFAULT:PQ && \
+     dnf clean all && rm -rf /var/cache/*)
 
 # Final stage: Base RHEL9 image with PQ crypto-policies
 FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 
 # Copy crypto-policies configuration from builder stage
+# For CentOS builds, this will just copy the default policies since PQ setup was skipped
 COPY --from=builder /etc/crypto-policies/ /etc/crypto-policies/
 
 # A ubi9 image will expose python3 as /usr/bin/python. It does not contain


### PR DESCRIPTION
## Summary

Skip the DEFAULT:PQ crypto-policy configuration for CentOS-based OKD builds, as the PQ module is not available in CentOS Stream 10.

## Problem

Ref. [ART-20722](https://redhat.atlassian.net/browse/ART-20722)

OKD builds on CentOS Stream 10 were failing with:
```
Unknown policy `PQ`: file `PQ.pmod` not found
Error: building at STEP "RUN dnf install -y --nodocs crypto-policies-scripts && 
    update-crypto-policies --set DEFAULT:PQ && 
    dnf clean all && rm -rf /var/cache/*": exit status 1
```

The `DEFAULT:PQ` (Post-Quantum) crypto-policy module exists in RHEL but is not available in CentOS Stream 10.

## Solution

Conditionally skip the entire crypto-policies-scripts installation and PQ setup for CentOS-based builds:
- **For CentOS (OKD):** Skip `crypto-policies-scripts` package installation and PQ configuration entirely
- **For RHEL (OCP):** Install `crypto-policies-scripts` and configure `DEFAULT:PQ` as before

The default crypto-policies are still copied to the final image from the builder stage.

## Related

- Build failure: https://jenkins-rhcos--prod-pipeline.apps.int.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/build-node-image/6137/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated the container image build process to apply post-quantum cryptographic policies for non–CentOS builds, while keeping CentOS-based builds on the default crypto-policy set.
* **Security**
  * Ensures the resulting images consistently reflect the appropriate cryptographic policy configuration for the target operating system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->