### PR TITLE
NE-2716: Replace iptables with nftables in origin-egress-router

### DIFF
--- a/egress/router/Dockerfile
+++ b/egress/router/Dockerfile
@@ -5,7 +5,7 @@
 
 FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
 
-RUN INSTALL_PKGS="iproute iputils iptables-nft" && \
+RUN INSTALL_PKGS="iproute iputils nftables" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all

--- a/egress/router/egress-router.sh
+++ b/egress/router/egress-router.sh
@@ -60,7 +60,7 @@ function validate_port() {
     fi
 }
 
-function gen_iptables_rules() {
+function gen_nft_rules() {
     if [[ -z "${EGRESS_DESTINATION:-}" ]]; then
         die "EGRESS_DESTINATION unspecified"
     fi
@@ -79,17 +79,17 @@ function gen_iptables_rules() {
         localport=""
         if [[ "${dest}" =~ ^${IP_REGEX}$ ]]; then
             # single IP address: do fallback "all ports to same IP"
-            echo -A PREROUTING -i eth0 -j DNAT --to-destination "${dest}"
+            echo "add rule ip nat prerouting iifname \"eth0\" dnat to ${dest}"
             did_fallback=1
 
         elif [[ "${dest}" =~ ^${PORT_REGEX}\ +${PROTO_REGEX}\ +${IP_REGEX}$ ]]; then
             read localport proto destip <<< "${dest}"
-            echo -A PREROUTING -i eth0 -p "${proto}" --dport "${localport}" -j DNAT --to-destination "${destip}"
+            echo "add rule ip nat prerouting iifname \"eth0\" ${proto} dport ${localport} dnat to ${destip}"
 
         elif [[ "${dest}" =~ ^${PORT_REGEX}\ +${PROTO_REGEX}\ +${IP_REGEX}\ +${PORT_REGEX}$ ]]; then
             read localport proto destip destport <<< "${dest}"
             validate_port ${destport}
-            echo -A PREROUTING -i eth0 -p "${proto}" --dport "${localport}" -j DNAT --to-destination "${destip}:${destport}"
+            echo "add rule ip nat prerouting iifname \"eth0\" ${proto} dport ${localport} dnat to ${destip}:${destport}"
 
         else
             die "EGRESS_DESTINATION value '${dest}' is invalid" 1>&2
@@ -106,16 +106,24 @@ function gen_iptables_rules() {
             fi
         fi
     done <<< "${EGRESS_DESTINATION}"
-    echo -A POSTROUTING -o macvlan0 -j SNAT --to-source "${EGRESS_SOURCE}"
+    echo "add rule ip nat postrouting oifname \"macvlan0\" snat to ${EGRESS_SOURCE}"
 }
 
-function setup_iptables() {
-    iptables -t nat -F
-    ( echo "*nat";
-      echo ":PREROUTING ACCEPT [0:0]";
-      echo ":POSTROUTING ACCEPT [0:0]";
-      gen_iptables_rules;
-      echo "COMMIT" ) | iptables-restore --noflush --table nat
+function setup_nft() {
+    {
+        cat <<'NFT'
+table ip nat {
+  chain prerouting {
+    type nat hook prerouting priority dstnat; policy accept;
+  }
+  chain postrouting {
+    type nat hook postrouting priority srcnat; policy accept;
+  }
+}
+flush table ip nat
+NFT
+        gen_nft_rules
+    } | nft -f -
 }
 
 function wait_until_killed() {
@@ -140,12 +148,12 @@ function wait_until_killed() {
 case "${EGRESS_ROUTER_MODE:=legacy}" in
     init)
         setup_network
-        setup_iptables
+        setup_nft
         ;;
 
     legacy)
         setup_network
-        setup_iptables
+        setup_nft
         wait_until_killed
         ;;
 
@@ -158,7 +166,7 @@ case "${EGRESS_ROUTER_MODE:=legacy}" in
         ;;
 
     unit-test)
-        gen_iptables_rules
+        gen_nft_rules
         ;;
 
     *)

--- a/egress/router/egress_router_test.go
+++ b/egress/router/egress_router_test.go
@@ -19,8 +19,8 @@ func TestEgressRouter(t *testing.T) {
 			gateway: "1.1.1.1",
 			dest:    "10.1.2.3",
 			output: `
--A PREROUTING -i eth0 -j DNAT --to-destination 10.1.2.3
--A POSTROUTING -o macvlan0 -j SNAT --to-source 1.2.3.4
+add rule ip nat prerouting iifname "eth0" dnat to 10.1.2.3
+add rule ip nat postrouting oifname "macvlan0" snat to 1.2.3.4
 `,
 		},
 		{
@@ -28,8 +28,8 @@ func TestEgressRouter(t *testing.T) {
 			gateway: "1.1.1.1",
 			dest:    "10.1.2.3",
 			output: `
--A PREROUTING -i eth0 -j DNAT --to-destination 10.1.2.3
--A POSTROUTING -o macvlan0 -j SNAT --to-source 1.2.3.4
+add rule ip nat prerouting iifname "eth0" dnat to 10.1.2.3
+add rule ip nat postrouting oifname "macvlan0" snat to 1.2.3.4
 `,
 		},
 		{
@@ -37,8 +37,8 @@ func TestEgressRouter(t *testing.T) {
 			gateway: "1.1.1.1",
 			dest:    "10.1.2.3",
 			output: `
--A PREROUTING -i eth0 -j DNAT --to-destination 10.1.2.3
--A POSTROUTING -o macvlan0 -j SNAT --to-source 1.2.3.4
+add rule ip nat prerouting iifname "eth0" dnat to 10.1.2.3
+add rule ip nat postrouting oifname "macvlan0" snat to 1.2.3.4
 `,
 		},
 		{
@@ -46,8 +46,8 @@ func TestEgressRouter(t *testing.T) {
 			gateway: "1.1.1.1",
 			dest:    "10.1.2.3\n",
 			output: `
--A PREROUTING -i eth0 -j DNAT --to-destination 10.1.2.3
--A POSTROUTING -o macvlan0 -j SNAT --to-source 1.2.3.4
+add rule ip nat prerouting iifname "eth0" dnat to 10.1.2.3
+add rule ip nat postrouting oifname "macvlan0" snat to 1.2.3.4
 `,
 		},
 		{
@@ -55,8 +55,8 @@ func TestEgressRouter(t *testing.T) {
 			gateway: "1.1.1.1",
 			dest:    "80 tcp 10.4.5.6",
 			output: `
--A PREROUTING -i eth0 -p tcp --dport 80 -j DNAT --to-destination 10.4.5.6
--A POSTROUTING -o macvlan0 -j SNAT --to-source 1.2.3.4
+add rule ip nat prerouting iifname "eth0" tcp dport 80 dnat to 10.4.5.6
+add rule ip nat postrouting oifname "macvlan0" snat to 1.2.3.4
 `,
 		},
 		{
@@ -64,8 +64,8 @@ func TestEgressRouter(t *testing.T) {
 			gateway: "1.1.1.1",
 			dest:    "8080 tcp 10.7.8.9 80",
 			output: `
--A PREROUTING -i eth0 -p tcp --dport 8080 -j DNAT --to-destination 10.7.8.9:80
--A POSTROUTING -o macvlan0 -j SNAT --to-source 1.2.3.4
+add rule ip nat prerouting iifname "eth0" tcp dport 8080 dnat to 10.7.8.9:80
+add rule ip nat postrouting oifname "macvlan0" snat to 1.2.3.4
 `,
 		},
 		{
@@ -73,9 +73,9 @@ func TestEgressRouter(t *testing.T) {
 			gateway: "1.1.1.1",
 			dest:    "80 tcp 10.4.5.6\n8080 tcp 10.7.8.9 80",
 			output: `
--A PREROUTING -i eth0 -p tcp --dport 80 -j DNAT --to-destination 10.4.5.6
--A PREROUTING -i eth0 -p tcp --dport 8080 -j DNAT --to-destination 10.7.8.9:80
--A POSTROUTING -o macvlan0 -j SNAT --to-source 1.2.3.4
+add rule ip nat prerouting iifname "eth0" tcp dport 80 dnat to 10.4.5.6
+add rule ip nat prerouting iifname "eth0" tcp dport 8080 dnat to 10.7.8.9:80
+add rule ip nat postrouting oifname "macvlan0" snat to 1.2.3.4
 `,
 		},
 		{
@@ -83,10 +83,10 @@ func TestEgressRouter(t *testing.T) {
 			gateway: "1.1.1.1",
 			dest:    "80 tcp 10.4.5.6\n8080 tcp 10.7.8.9 80\n10.1.2.3",
 			output: `
--A PREROUTING -i eth0 -p tcp --dport 80 -j DNAT --to-destination 10.4.5.6
--A PREROUTING -i eth0 -p tcp --dport 8080 -j DNAT --to-destination 10.7.8.9:80
--A PREROUTING -i eth0 -j DNAT --to-destination 10.1.2.3
--A POSTROUTING -o macvlan0 -j SNAT --to-source 1.2.3.4
+add rule ip nat prerouting iifname "eth0" tcp dport 80 dnat to 10.4.5.6
+add rule ip nat prerouting iifname "eth0" tcp dport 8080 dnat to 10.7.8.9:80
+add rule ip nat prerouting iifname "eth0" dnat to 10.1.2.3
+add rule ip nat postrouting oifname "macvlan0" snat to 1.2.3.4
 `,
 		},
 		{
@@ -112,10 +112,10 @@ func TestEgressRouter(t *testing.T) {
 # No, seriously, don't add anything here
 `,
 			output: `
--A PREROUTING -i eth0 -p tcp --dport 80 -j DNAT --to-destination 10.4.5.6
--A PREROUTING -i eth0 -p tcp --dport 8080 -j DNAT --to-destination 10.7.8.9:80
--A PREROUTING -i eth0 -j DNAT --to-destination 10.1.2.3
--A POSTROUTING -o macvlan0 -j SNAT --to-source 1.2.3.4
+add rule ip nat prerouting iifname "eth0" tcp dport 80 dnat to 10.4.5.6
+add rule ip nat prerouting iifname "eth0" tcp dport 8080 dnat to 10.7.8.9:80
+add rule ip nat prerouting iifname "eth0" dnat to 10.1.2.3
+add rule ip nat postrouting oifname "macvlan0" snat to 1.2.3.4
 `,
 		},
 	}


### PR DESCRIPTION
## Summary

- Replace the deprecated `iptables-nft` shim with the native `nftables` package in the egress router container image
- Rename `gen_iptables_rules`/`setup_iptables` to `gen_nft_rules`/`setup_nft`
- Translate all DNAT/SNAT rule output from iptables-restore format to nft format
- Create nat table and chains atomically via `nft -f -`, loading table creation, flush, and all generated rules in a single transaction
- Update all 9 Go unit test expected outputs to match the new nft rule format

## Why

iptables is deprecated in RHEL 9 and the `ip_tables` kernel module is [removed in RHEL 10](https://github.com/moby/moby/issues/49020). The `iptables-nft` userspace shim [remains but is deprecated](https://access.redhat.com/solutions/6739041). This migrates to native nft before the shim is removed entirely.

## Reference

nft rule syntax derived from the [nftables wiki — Moving from iptables to nftables](https://wiki.nftables.org/wiki-nftables/index.php/Moving_from_iptables_to_nftables).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the egress router to generate nftables-style NAT rules for forwarding (DNAT) and outbound traffic (SNAT).
  * Router container now includes nftables tooling.

* **Bug Fixes**
  * Improved destination parsing for NAT rule generation, including validation for the `destip:destport` form.
  * Updated runtime wiring to apply the nftables ruleset in one load.

* **Tests**
  * Refreshed egress router tests to match the new nftables rule rendering format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->