### PR TITLE
NE-2223: Bump HAProxy to 3.2 in egress DNS proxy

### DIFF
--- a/egress/dns-proxy/Dockerfile
+++ b/egress/dns-proxy/Dockerfile
@@ -3,10 +3,10 @@
 #
 # The standard name for this image is openshift/origin-egress-dns-proxy
 
-FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 
 # HAProxy 1.6+ version is needed to leverage DNS resolution at runtime.
-RUN INSTALL_PKGS="haproxy28 rsyslog" && \
+RUN INSTALL_PKGS="haproxy32 rsyslog" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
## Summary

Bump the egress DNS proxy from haproxy28 to haproxy32, and update the base image to 5.0 for RPM availability.

This aligns with the HAProxy 3.2 bump in the router image (https://github.com/openshift/router/pull/792).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying runtime image to the latest platform version.
  * Upgraded the bundled HAProxy version for improved compatibility and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->