### PR TITLE
OCPBUGS-99649: Reinstall tzdata if /usr/share/zoneinfo is missing

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -14,6 +14,7 @@ RUN INSTALL_PKGS=" \
       " && \
     echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
     yum install -y ${INSTALL_PKGS} && \
+    ( test -d /usr/share/zoneinfo || yum reinstall -y tzdata || yum install -y tzdata ) && \
     yum clean all && \
     mkdir -p /var/lib/origin
 

--- a/base/Dockerfile.rhel
+++ b/base/Dockerfile.rhel
@@ -17,6 +17,7 @@ RUN INSTALL_PKGS=" \
     echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
     yum install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=False ${INSTALL_PKGS} && \
     ( test -e /usr/bin/python ||  alternatives --set python /usr/bin/python3 ) && \
+    ( test -d /usr/share/zoneinfo || yum reinstall -y tzdata || yum install -y tzdata ) && \
     yum clean all && rm -rf /var/cache/*
 
 # Enable x509 common name matching for golang 1.15 and beyond.

--- a/base/Dockerfile.rhel9
+++ b/base/Dockerfile.rhel9
@@ -28,6 +28,7 @@ RUN INSTALL_PKGS=" \
     echo 'skip_missing_names_on_install=0' >> /etc/yum.conf && \
     echo 'install_weak_deps=0' >> /etc/yum.conf && \
     dnf install -y --nodocs ${INSTALL_PKGS} && \
+    ( test -d /usr/share/zoneinfo || dnf reinstall -y --nodocs tzdata || dnf install -y --nodocs tzdata ) && \
     dnf clean all && rm -rf /var/cache/*
 
 # OKD-specific changes


### PR DESCRIPTION
## Summary
- In `base/Dockerfile`, `base/Dockerfile.rhel`, and `base/Dockerfile.rhel9`, check for `/usr/share/zoneinfo` after package install and reinstall `tzdata` if it's absent, falling back to a plain install if `reinstall` fails (e.g. microdnf's stricter reinstall semantics, or `tzdata` missing from the rpm db entirely).
- ubi8-minimal and ubi9-minimal keep the `tzdata` package installed but strip `/usr/share/zoneinfo` from the image to save space. This detects that condition and reinstalls `tzdata` to restore it.

Note: RHEL10 minimal images do not ship `tzdata` by design, so this check should not be extended to re-add it there. Assuming anyone who has already moved to RHEL10 has tested successfully without it.

## Test plan
- [ ] Build each base image and confirm `/usr/share/zoneinfo` is present
- [ ] Confirm no-op path (directory already present) adds no extra work

Fixes OCPBUGS-99649

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added post-quantum cryptography policy support to RHEL 9-based images (enabled on non-CentOS builds).
* **Bug Fixes**
  * Improved timezone handling during container builds by automatically restoring or installing missing timezone data, ensuring `/usr/share/zoneinfo` is available.
  * Applied the same timezone data safeguards across the base, RHEL, and RHEL 9 image variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->